### PR TITLE
Improve Call Log visibility and organization

### DIFF
--- a/luci-app-sms-tool-js/htdocs/luci-static/resources/view/modem/smsconfig.js
+++ b/luci-app-sms-tool-js/htdocs/luci-static/resources/view/modem/smsconfig.js
@@ -1197,8 +1197,12 @@ return view.extend({
 				});
 			}
 		};
-		
-		o = s.taboption('smstab' , form.Value, 'callport', _('Call log reading port'),
+
+		//TAB CALL LOG
+
+		s.tab('calllogtab', _('Call Log Settings'));
+
+		o = s.taboption('calllogtab' , form.Value, 'callport', _('Call log reading port'),
 			_('Select one of the available ttyUSBX ports.'));
 		devs.sort((a, b) => a.name > b.name);
 		devs.forEach(dev => o.value('/dev/' + dev.name));
@@ -1206,7 +1210,7 @@ return view.extend({
 		o.placeholder = _('Please select a port');
 		o.rmempty = false;
 		
-        o = s.taboption('smstab', form.Flag, 'calllog_enabled', _('Enable call log daemon'),
+        o = s.taboption('calllogtab', form.Flag, 'calllog_enabled', _('Enable call log daemon'),
 	        _('Background process to log incoming and missed calls.'));
         o.rmempty = false;
         o.default = '0';

--- a/luci-app-sms-tool-js/root/usr/share/luci/menu.d/luci-app-sms-tool-js.json
+++ b/luci-app-sms-tool-js/root/usr/share/luci/menu.d/luci-app-sms-tool-js.json
@@ -45,9 +45,6 @@
 		"action": {
 			"type": "view",
 			"path": "modem/calllog"
-		},
-		"depends": {
-			"fs": { "/tmp/sms_tool_call_log.json": "file" }
 		}
 	},
 


### PR DESCRIPTION
This PR introduces several improvements to the Call Log feature to enhance discoverability and user experience:

1. **Always-Visible Menu:** Removed the filesystem dependency from the LuCI menu configuration. The "Call Log" entry is now always visible, allowing users to discover the feature even if the daemon is not yet active.
2. **Dedicated Configuration Tab:** Relocated Call Log settings (port selection and daemon toggle) from the general SMS settings to a new, dedicated "Call Log Settings" tab for better organization.
3. **Improved Feedback:** The Call Log view now gracefully handles cases where the daemon is disabled, providing a helpful warning message and instructions on how to enable it.

These changes make the Call Log feature more intuitive and easier to set up for new users.