### PR TITLE
fix: add -ehlo to mailsend command to fix SMTP AUTH relay error

### DIFF
--- a/luci-app-sms-tool-js/root/usr/libexec/rpcd/sms_forward
+++ b/luci-app-sms-tool-js/root/usr/libexec/rpcd/sms_forward
@@ -56,7 +56,7 @@ send_email() {
         *) security_opts="-starttls -auth-login" ;;
     esac
     
-    result=$(mailsend $security_opts \
+    result=$(mailsend $security_opts -ehlo \
         -smtp "$smtp" -port "$port" \
         -ct 5 -read-timeout 5 \
         -cs utf-8 \


### PR DESCRIPTION
when mailsend command missing -ehlo command,some servers won't response available auth method which lead to mailsend skip the auth process and cause the sending process fail.
For  Issue:https://github.com/4IceG/luci-app-sms-tool-js/issues/45